### PR TITLE
try bench to compare 2 functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # learn-golang
+
+➜  hello git:(master) ✗ go test -bench=. 
+goos: darwin
+goarch: amd64
+pkg: github.com/martishevich/hello
+BenchmarkMyStrToInt-8           196373287                7.00 ns/op
+BenchmarkMyStrToInt2-8           2078641               616 ns/op
+PASS
+ok      github.com/martishevich/hello   4.270s
+
+
+as we can see, strconv.Atoi() faster then fmt.Sscanf(s, "%d", &number)

--- a/main.go
+++ b/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func myStrToInt(s string) (int, error) {
+	return strconv.Atoi(s)
+}
+
+func myStrToInt2(s string) (int, error) {
+	var number int
+	_, err := fmt.Sscanf(s, "%d", &number)
+	return number, err
+}
+
+func main() {
+	res, err := myStrToInt("3")
+	if err != nil {
+		fmt.Println(err)
+		panic("")
+	}
+	fmt.Println(res)
+
+
+	res2, err2 := myStrToInt2("3")
+	if err2 != nil {
+		fmt.Println(err2)
+		panic("")
+	}
+	fmt.Println(res2)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMyStrToInt(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt("5")
+	assert.Nil(err)
+	assert.Equal(5, result)
+}
+
+func TestZero(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt("0")
+	assert.Nil(err)
+	assert.Equal(0, result)
+}
+
+func TestNegative(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt("-3")
+	assert.Nil(err)
+	assert.Equal(-3, result)
+}
+
+func TestEmpty(t *testing.T) {
+	assert := assert.New(t)
+	_, err := myStrToInt("")
+	assert.NotNil(err)
+}
+
+func TestString(t *testing.T) {
+	assert := assert.New(t)
+	_, err := myStrToInt("epam")
+	assert.NotNil(err)
+}
+
+func TestALotOfZero(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt("0000")
+	assert.Nil(err)
+	assert.Equal(0, result)
+}
+
+func TestWithZeroPrefix(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt("07")
+	assert.Nil(err)
+	assert.Equal(7, result)
+}
+
+
+
+
+
+
+func Test2MyStrToInt(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt2("5")
+	assert.Nil(err)
+	assert.Equal(5, result)
+}
+
+func Test2Zero(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt2("0")
+	assert.Nil(err)
+	assert.Equal(0, result)
+}
+
+func Test2Negative(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt2("-3")
+	assert.Nil(err)
+	assert.Equal(-3, result)
+}
+
+func Test2Empty(t *testing.T) {
+	assert := assert.New(t)
+	_, err := myStrToInt2("")
+	assert.NotNil(err)
+}
+
+func Test2String(t *testing.T) {
+	assert := assert.New(t)
+	_, err := myStrToInt2("epam")
+	assert.NotNil(err)
+}
+
+func Test2ALotOfZero(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt2("0000")
+	assert.Nil(err)
+	assert.Equal(0, result)
+}
+
+func Test2WithZeroPrefix(t *testing.T) {
+	assert := assert.New(t)
+	result, err := myStrToInt2("07")
+	assert.Nil(err)
+	assert.Equal(7, result)
+}
+
+func BenchmarkMyStrToInt(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		myStrToInt("13")
+	}
+}
+
+func BenchmarkMyStrToInt2(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		myStrToInt2("13")
+	}
+}


### PR DESCRIPTION
Implement string to int converter, like
func myStrToInt(s str) (int, error){}
Cover it with tests
Implement another string to int converter, like
func myStrToInt2(s str) (int, error){}
It should pass same tests as in #1, but must be implemented another way
Add benchmarks for both myStrToInt2 and myStrToInt.
Find the fastest func